### PR TITLE
Update smoke check workflow to trigger "Dependency Review" on pull requests only

### DIFF
--- a/.github/workflows/smoke-check.yml
+++ b/.github/workflows/smoke-check.yml
@@ -95,6 +95,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:


### PR DESCRIPTION
# Update smoke-check to run dependency review on PR only

## Description
<!-- Please provide a concise description of the change. -->
The Dependency review action should only run on PR not push
## Related issues

<!-- If this PR addresses one or more open issues, include the issue numbers in one of these formats:
Closes #XXXXX
Related to #XXXXX
-->


@coderabbit summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the smoke check workflow to conditionally execute the "Dependency Review" job only for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->